### PR TITLE
バグの修正：ファイルの削除、404に実装

### DIFF
--- a/files/index.js
+++ b/files/index.js
@@ -23,11 +23,13 @@ exports.handler = async (event) => {
 
 const hadnleGetMethod = async ({ fileKey }) => {
   const body = await getFile(fileKey)
+  const isNotFound = body === null
+
   return {
-    statusCode: 200,
+    statusCode: isNotFound ? 404 : 200,
     headers: {
       "Access-Control-Allow-Origin": process.env.FRONT,
     },
-    body: body
+    body: isNotFound ? 'requested resource is not found' : body
   }
 }


### PR DESCRIPTION
## 対応内容
### ファイルの削除
- s3のメタ情報のタイムゾーンがUTCだったので、それにあわせて修正
    - 現象として、1時間たたずにファイルが削除されていた

### ファイル取得APIの404実装
- ファイルが存在しない場合は、404を返すように修正